### PR TITLE
Fixed displaying of the bonus percentage

### DIFF
--- a/venue/components/MyCurrentRewards.vue
+++ b/venue/components/MyCurrentRewards.vue
@@ -5,7 +5,7 @@
       <span v-else>N/A</span> VTX
     </div>
     <div class="has-text-centered">
-      <span v-if="bonus > 0" style="width:100%; margin:5px">{{ forumUserRank }} Bonus: {{ bonus }}% (included)</span>    
+      <span v-if="bonus > 0">{{ forumUserRank }} Bonus: {{ bonus }}% (included)</span>    
     </div>
     <div class="is-size-5 has-text-centered text-transform-uppercase"><span class="icon"><i class="fas fa-star" style="color:#fbc02d"/></span>{{ $t('labels.my_current_rewards') }}</div>
   </div>


### PR DESCRIPTION
Fixed the issue [242](https://github.com/Volentix/venue-client/issues/242)
Bonus percentage text is now displayed if the bonus is more than 0 for the user.