### PR TITLE
234 fixed the muiltiplier and total post points

### DIFF
--- a/venue/components/PointsDetailsInfo.vue
+++ b/venue/components/PointsDetailsInfo.vue
@@ -17,7 +17,7 @@
             
       <div class="box">
         <div class="is-size-5">
-          {{ $t('points_details.your_total_posts') }} X {{ calcMultiplier(bonusPercentage) }} = <u>{{ $t('points_details.points', { count: myPoints }) }}</u>
+          {{ $t('points_details.your_total_posts') }} X {{ calcMultiplier(mybonusPercentage) }} = <u>{{ $t('points_details.points', { count: myPoints }) }}</u>
         </div>
         <div class="is-size-5">
           {{ $t('points_details.your_total_points') }} X {{ vtxPerPoint }} = {{ myTokens }} VTX
@@ -85,8 +85,6 @@ export default {
       let availableRewardsNumber = parseFloat(
         this.availableTokens.replace(",", "")
       );
-      console.log(pointsBreakdown);
-      //this.multiplier = pointsBreakdown.settings.post_points_multiplier;
       this.totalPostPoints = pointsBreakdown.sitewide_stats.total_post_points;
       this.totalBonusPoints = pointsBreakdown.sitewide_stats.total_bonus_points;
       this.totalPointsNum = this.totalPostPoints + this.totalBonusPoints;
@@ -95,15 +93,14 @@ export default {
       this.vtxPerPoint = (availableRewardsNumber / this.totalPointsNum).toFixed(
         2
       );
-      //this.myPoints = pointsBreakdown.user_stats.total_post_points;
       this.bonus = pointsBreakdown.sitewide_stats.bonus_points;
       this.loaded = true;
     },
     calcPoints(numPosts, bonus) {
       numPosts * (100 + bonus);
     },
-    calcMultiplier(bonus) {
-      return 100 + bonus;
+    calcMultiplier(bonusPercentage) {
+      return 100 * (1 + bonusPercentage / 100);
     }
   }
 };


### PR DESCRIPTION
Points/rewards detailed info:
 
1. Multiplier calculation is changed. Now it uses user's bonus percantage.
2. Total post points are displayed correctly now. 

Stingray's campaign activity:
![image](https://user-images.githubusercontent.com/8875863/43402957-e393336e-93e1-11e8-9c17-33ce81bfce35.png)
Multiplier and total post points:
![image](https://user-images.githubusercontent.com/8875863/43402906-c60c7ed6-93e1-11e8-9dc7-6ca87e632517.png)
