### PR TITLE
Fix broken links on the SignUp page

### DIFF
--- a/venue/components/Signup.vue
+++ b/venue/components/Signup.vue
@@ -14,7 +14,7 @@
       <div class="field">
         <b-checkbox v-model="newsletter">{{ $t('auth.msg_newsletter') }}</b-checkbox>
       </div>
-      <div class="field" v-html="$t('auth.msg_policies')"/>
+      <div class="field" v-html="$t('auth.msg_policies', ['https://volentix.io/privacy.html', 'https://volentix.io/terms.html'])"/>
       <b-field>
         <button class="button is-primary" type="submit">{{ $t('nav.sign_up') }}</button>
       </b-field>

--- a/venue/lang/en-CA.js
+++ b/venue/lang/en-CA.js
@@ -23,7 +23,7 @@ module.exports = {
       "Your email address has not been verified. Please check your email account.",
     msg_newsletter: "Also add me to your newsletter distribution list",
     msg_policies:
-      "By signing up, you agree to the Volentix <a href='https://volentix.io/privacy.html' target='_blank'>privacy policy</a> and <a href='https://volentix.io/terms.html' target='_blank'>terms of use</a>",
+      "By signing up, you agree to the Volentix <a href='{0}' target='_blank'>privacy policy</a> and <a href='{1}' target='_blank'>terms of use</a>",
     msg_email_verification:
       "Please click the email verification link we've just emailed to you to activate your Venue account.",
     msg_logging_out: "Logging out... "


### PR DESCRIPTION
Fixed broken links for privacy policy and terms of use on the Sign Up page.

![image](https://user-images.githubusercontent.com/8875863/44214398-0c3a6d00-a13e-11e8-975e-bf448613acb5.png)

![image](https://user-images.githubusercontent.com/8875863/44214415-19575c00-a13e-11e8-97a7-1244671714c9.png)
