### PR TITLE
Fix points details from infinity to zero

### DIFF
--- a/venue/components/PointsDetailsInfo.vue
+++ b/venue/components/PointsDetailsInfo.vue
@@ -90,10 +90,11 @@ export default {
       this.totalBonusPoints = pointsBreakdown.sitewide_stats.total_bonus_points;
       this.totalPointsNum = this.totalPostPoints + this.totalBonusPoints;
       this.totalPoints = this.totalPointsNum;
+      this.vtxPerPoint =
+        this.totalPointsNum == 0
+          ? 0
+          : (availableRewardsNumber / this.totalPointsNum).toFixed(2);
       this.totalPosts = pointsBreakdown.sitewide_stats.total_posts;
-      this.vtxPerPoint = (availableRewardsNumber / this.totalPointsNum).toFixed(
-        2
-      );
       this.bonus = pointsBreakdown.sitewide_stats.bonus_points;
       this.loaded = true;
     },


### PR DESCRIPTION
Fix of #278 
When there are no points for user points detail screen will display zero instead of Infinity.

![capture](https://user-images.githubusercontent.com/8875863/44218964-d6e74c80-a148-11e8-92dd-6feda0cf3dfa.PNG)
