### PR TITLE
Add a blank line at the Sign Up

### DIFF
--- a/venue/components/Signup.vue
+++ b/venue/components/Signup.vue
@@ -25,6 +25,7 @@
           <p>
             {{ $t('auth.msg_email_verification') }}
           </p>
+          <br>
           <p>
             {{ $t('auth.msg_email_check_spam_folder') }}
           </p>


### PR DESCRIPTION
Added a blank line between two paragraphs:
![screen shot 2018-08-27 at 10 19 37 am](https://user-images.githubusercontent.com/8875863/44665481-036e5480-a9e4-11e8-8f35-658347f932b4.png)
